### PR TITLE
Lower-bound seaborn in dev env

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -20,10 +20,10 @@ dependencies:
   - gdown
   - joblib
   - netcdf4
-  - ptitprince
   - pygeos
   - regionmask >=0.9
   - scipy
+  - seaborn >=0.13.2
   #
   # Development and tests
   - flit


### PR DESCRIPTION
This version works with current mpl. ptitprince pins to Seaborn 0.11, causing issues with current mpl. but we aren't currently using ptitprince anyway.