### PR TITLE
Help GeoPandas detect geometry column in test

### DIFF
--- a/test_tams.py
+++ b/test_tams.py
@@ -203,8 +203,7 @@ def test_classify_empty():
 def test_classify_cols_check():
     cs = gpd.GeoDataFrame(
         columns=["mcs_id", "geometry", "time", "area_km2", "area219_km2"],
-        data=np.full((1, 5), np.nan),
-        geometry="geometry",
+        data=[[0, None, pd.NaT, np.nan, np.nan]],
         crs="EPSG:4326",
     )
     with pytest.raises(ValueError, match="missing these columns"):

--- a/test_tams.py
+++ b/test_tams.py
@@ -204,6 +204,7 @@ def test_classify_cols_check():
     cs = gpd.GeoDataFrame(
         columns=["mcs_id", "geometry", "time", "area_km2", "area219_km2"],
         data=np.full((1, 5), np.nan),
+        geometry="geometry",
         crs="EPSG:4326",
     )
     with pytest.raises(ValueError, match="missing these columns"):


### PR DESCRIPTION
Previously it worked without this, but now (GeoPandas v1.1.0) we were getting:

`Assigning CRS to a GeoDataFrame without a geometry column is not supported. Supply geometry using the 'geometry=' keyword argument, or by providing a DataFrame with column name 'geometry'`