### PR TITLE
Revert "Install `attr` in RTD to please netCDF for now"

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,8 +4,6 @@ build:
   os: "ubuntu-lts-latest"
   tools:
     python: "mambaforge-latest"
-  apt_packages:
-    - attr
   jobs:
     post_install:
       - pip install -e . --no-deps -vv


### PR DESCRIPTION
Reverts knubez/TAMS#66

should no longer be necessary with the new libnetcdf build