### PR TITLE
Fix docs (ellipse fit example; GIF)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,10 +10,13 @@ import pybtex.plugin
 from pybtex.database import Entry, Person
 from pybtex.style.labels import BaseLabelStyle
 from pybtex.style.sorting import BaseSortingStyle
+from sphinx.util import logging
 
-# De-clutter tracebacks on RTD
+logger = logging.getLogger(__name__)
+
 if "READTHEDOCS" in os.environ:
-    ipython_dir = Path(tempfile.gettempdir()) / "tams_ipython_clean_logs"
+    logger.info("Running on Read the Docs, configuring IPython for monochrome.")
+    ipython_dir = Path(tempfile.gettempdir()) / "ipython_monochrome"
     (ipython_dir / "profile_default").mkdir(parents=True, exist_ok=True)
     with open(ipython_dir / "profile_default" / "ipython_config.py", "w") as f:
         f.write("c.InteractiveShell.colors = 'NoColor'\n")

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,12 +1,23 @@
 from __future__ import annotations
 
+import os
+import tempfile
 from collections.abc import Generator
 from datetime import datetime
+from pathlib import Path
 
 import pybtex.plugin
 from pybtex.database import Entry, Person
 from pybtex.style.labels import BaseLabelStyle
 from pybtex.style.sorting import BaseSortingStyle
+
+# De-clutter tracebacks on RTD
+if "READTHEDOCS" in os.environ:
+    ipython_dir = Path(tempfile.gettempdir()) / "tams_ipython_clean_logs"
+    (ipython_dir / "profile_default").mkdir(parents=True, exist_ok=True)
+    with open(ipython_dir / "profile_default" / "ipython_config.py", "w") as f:
+        f.write("c.InteractiveShell.colors = 'NoColor'\n")
+    os.environ["IPYTHONDIR"] = str(ipython_dir)
 
 project = "tams"
 html_title = "TAMS"

--- a/docs/examples/sample-satellite-data.ipynb
+++ b/docs/examples/sample-satellite-data.ipynb
@@ -175,7 +175,7 @@
     "    gs = fig.add_gridspec(\n",
     "        2, 2,\n",
     "        width_ratios=(1, 1), height_ratios=(aspect * 2 + 1, 1),\n",
-    "        left=0.1, right=0.9, bottom=0.1, top=0.9,\n",
+    "        left=0.005, right=0.995, bottom=0.14, top=0.87,\n",
     "        wspace=0.05, hspace=0.18,\n",
     "    )\n",
     "\n",
@@ -226,7 +226,7 @@
     "    ax.set_title(f\"{t:%Y-%m-%d %HZ}\", loc=\"left\", size=11)\n",
     "\n",
     "frames = Frames(tb_, plot, dim=\"time\")\n",
-    "frames.write(dpi=120)\n",
+    "frames.write(dpi=120, savefig_kws=dict(bbox_inches=None))\n",
     "frames.to_gif(\"./tb.gif\", fps=1, magick=\"READTHEDOCS\" not in os.environ)"
    ]
   },

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -8,7 +8,7 @@ dependencies:
   # Core dependencies
   - geopandas >=1.0
   - matplotlib >=3.4,!=3.8.0
-  - numpy
+  - numpy <2.5
   - pandas =2.*
   - scikit-image
   - shapely


### PR DESCRIPTION
In #95 noticed there was an error in skimage EllipseModel fitting in the identify example nb.
```
skimage/measure/fit.py:952, in EllipseModel._estimate(self, data, warn_only)
    949     width, height = height, width
    950     phi += np.pi / 2
--> 952 phi %= np.pi
    954 # Revert normalization and set parameters.
    955 params = np.nan_to_num([x0, y0, width, height, phi]).real

TypeError: unsupported operand type(s) for %=: 'numpy.complex128' and 'float'
```