### PR TITLE
Enhance identify log messages

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -51,7 +51,7 @@
 - Logger level and handler can be controlled using {func}`tams.set_options`
   and should still work even when using `parallel=True`.
   The logs now include more information about the contouring,
-  including reasons for exclusion ({pull}`74`).
+  including reasons for exclusion ({pull}`74`, {pull}`98`).
 - Create idealized datasets for testing using {mod}`tams.idealized` ({pull}`80`).
 - {func}`tams.fit_ellipse` can be used to obtain the ellipse fit parameters
   used for the eccentricity calculation ({pull}`85`).

--- a/tams/core.py
+++ b/tams/core.py
@@ -266,11 +266,15 @@ def _contours_to_polygons(
     from shapely import Polygon
     from shapely.geometry.polygon import orient
 
+    logger = get_worker_logger()
+
     if cs.empty:
         return gpd.GeoDataFrame(
             geometry=[],
             crs="EPSG:4326",
         )
+
+    n0 = len(cs)
 
     # Preprocess by selecting closed contours, converting to polygons,
     # computing area, and sorting (smallest -> largest)
@@ -322,6 +326,8 @@ def _contours_to_polygons(
                 continue
             new_polys.append(cs.loc[i].contour)
 
+    logger.info(f"{n0} contours -> {len(new_polys)} polygons")
+
     return gpd.GeoDataFrame(
         geometry=new_polys,
         crs="EPSG:4326",
@@ -344,6 +350,8 @@ def _size_filter(
     import geopandas as gpd
 
     logger = get_worker_logger()
+
+    n0 = len(ce)
 
     # Drop small CEs (a CE with area < 4000 km2 can't have cold-core area of 4000)
     ce["area_km2"] = ce.to_crs("EPSG:32663").area / 10**6
@@ -398,6 +406,8 @@ def _size_filter(
             f"of big-enough CEs have enough cold-core area ({threshold} km2)"
         )
     ce = ce[big_enough].reset_index(drop=True)
+
+    logger.info(f"{len(ce)}/{n0} CEs retained after size filtering")
 
     return ce
 

--- a/tams/core.py
+++ b/tams/core.py
@@ -30,8 +30,13 @@ if TYPE_CHECKING:
 logger = get_logger()
 
 
+_KEEP_INVALID_CONTOUR_EXPLANATION_LOCATION = False
+
+
 def _remove_validity_explanation_location(s):
     """e.g. 'invalid closed (Ring Self-intersection[-77.6131744384766 37.6409950256348])'"""
+    if _KEEP_INVALID_CONTOUR_EXPLANATION_LOCATION:
+        return s
     return re.sub(r"\[.*?\]", "[...]", s)
 
 

--- a/tams/core.py
+++ b/tams/core.py
@@ -29,15 +29,16 @@ if TYPE_CHECKING:
 
 logger = get_logger()
 
+_RE_BRACKETED_COORDS = re.compile(r"\[[0-9eE+\-.,\s]+\]")
 
 _KEEP_INVALID_CONTOUR_EXPLANATION_LOCATION = False
 
 
-def _remove_validity_explanation_location(s):
+def _remove_validity_explanation_location(s: str) -> str:
     """e.g. 'invalid closed (Ring Self-intersection[-77.6131744384766 37.6409950256348])'"""
     if _KEEP_INVALID_CONTOUR_EXPLANATION_LOCATION:
         return s
-    return re.sub(r"\[.*?\]", "[...]", s)
+    return _RE_BRACKETED_COORDS.sub("[...]", s)
 
 
 def _contour_segs_to_gdf(

--- a/tams/core.py
+++ b/tams/core.py
@@ -106,7 +106,8 @@ def _contour_segs_to_gdf(
             try:
                 r = LinearRing(ls)
             except (ValueError, TopologicalError) as e:
-                skipped[f"invalid closed ({e})"] += 1
+                expl = _remove_validity_explanation_location(str(e))
+                skipped[f"invalid closed ({expl})"] += 1
                 continue
             if not r.is_valid:
                 expl = _remove_validity_explanation_location(explain_validity(r))

--- a/tams/core.py
+++ b/tams/core.py
@@ -35,7 +35,11 @@ _KEEP_INVALID_CONTOUR_EXPLANATION_LOCATION = False
 
 
 def _remove_validity_explanation_location(s: str) -> str:
-    """e.g. 'invalid closed (Ring Self-intersection[-77.6131744384766 37.6409950256348])'"""
+    """Obfuscate bracketed coordinate locations in Shapely messages.
+
+    Example: 'Ring Self-intersection[-77.6131744384766 37.6409950256348]'
+    -> 'Ring Self-intersection[...]'
+    """
     if _KEEP_INVALID_CONTOUR_EXPLANATION_LOCATION:
         return s
     return _RE_BRACKETED_COORDS.sub("[...]", s)

--- a/tams/core.py
+++ b/tams/core.py
@@ -8,6 +8,7 @@ users shouldn't need to import/use objects from this module directly.
 from __future__ import annotations
 
 import functools
+import re
 import warnings
 from typing import TYPE_CHECKING, NamedTuple
 
@@ -27,6 +28,11 @@ if TYPE_CHECKING:
 
 
 logger = get_logger()
+
+
+def _remove_validity_explanation_location(s):
+    """e.g. 'invalid closed (Ring Self-intersection[-77.6131744384766 37.6409950256348])'"""
+    return re.sub(r"\[.*?\]", "[...]", s)
 
 
 def _contour_segs_to_gdf(
@@ -98,7 +104,8 @@ def _contour_segs_to_gdf(
                 skipped[f"invalid closed ({e})"] += 1
                 continue
             if not r.is_valid:
-                skipped[f"invalid closed ({explain_validity(r)})"] += 1
+                expl = _remove_validity_explanation_location(explain_validity(r))
+                skipped[f"invalid closed ({expl})"] += 1
                 continue
             encloses_higher = r.is_ccw
             r_ccw = orient(Polygon(r)).exterior  # ensure consistent
@@ -116,7 +123,8 @@ def _contour_segs_to_gdf(
         else:
             encloses_higher = None
             if not ls.is_valid:
-                skipped[f"invalid open ({explain_validity(ls)})"] += 1
+                expl = _remove_validity_explanation_location(explain_validity(ls))
+                skipped[f"invalid open ({expl})"] += 1
                 continue
             if not ls.is_simple:
                 # e.g. self-intersecting

--- a/tests/test_identify.py
+++ b/tests/test_identify.py
@@ -9,8 +9,6 @@ import xarray as xr
 
 import tams
 
-tams.core._KEEP_INVALID_CONTOUR_EXPLANATION_LOCATION = True
-
 
 def test_contour_too_small_skipped():
     # With a few of the sample MPAS data time steps (e.g. `.isel(time=22)`)
@@ -100,7 +98,9 @@ def test_contour(msg_tb0, caplog):
         ),
     ],
 )
-def test_contour_skipped(contour, messages, caplog):
+def test_contour_skipped(contour, messages, caplog, monkeypatch):
+    monkeypatch.setattr(tams.core, "_KEEP_INVALID_CONTOUR_EXPLANATION_LOCATION", True)
+
     contours = [np.asarray(contour)]
     if isinstance(messages, str):
         messages = [messages]

--- a/tests/test_identify.py
+++ b/tests/test_identify.py
@@ -63,6 +63,13 @@ def test_contour(msg_tb0, caplog):
         assert gdf.dtypes["encloses_higher"] == "boolean"
 
 
+def test_message_coord_obfuscation():
+    s = "invalid closed (Ring Self-intersection[-77.6131744384766 37.6409950256348])"
+    obfuscated = tams.core._remove_validity_explanation_location(s)
+    obfuscated_again = tams.core._remove_validity_explanation_location(obfuscated)
+    assert obfuscated == "invalid closed (Ring Self-intersection[...])" == obfuscated_again
+
+
 @pytest.mark.parametrize(
     "contour, messages",
     [

--- a/tests/test_identify.py
+++ b/tests/test_identify.py
@@ -9,6 +9,8 @@ import xarray as xr
 
 import tams
 
+tams.core._KEEP_INVALID_CONTOUR_EXPLANATION_LOCATION = True
+
 
 def test_contour_too_small_skipped():
     # With a few of the sample MPAS data time steps (e.g. `.isel(time=22)`)


### PR DESCRIPTION
Kwesi tried contouring original 4-km MERGIR data and noticed CEs were not being identified. With logging on, there were many messages like `'invalid closed (Ring Self-intersection[-77.6131744384766 37.6409950256348])'`. Missing pixels and smoothness issues were leading to contours we reject in v0.2. This PR cleans up the logs a bit, so we just know the number of contours rejected for self-intersection instead of where they all occurred, and adds a few more messages.